### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,19 @@
 
+## [0.2.0](https://github.com/pkgforge-dev/appimagetool/compare/0.1.0...0.2.0) - 2026-05-04
+
+### ⛰️  Features
+
+- *(config)* Expose keep-mount, devel-release, and profile-timeout - ([b3db290](https://github.com/pkgforge-dev/appimagetool/commit/b3db290c18c43fa38e228b6f49dfd7cfa8ed1bfd))
+- *(config)* Split arch into runtime APPIMAGE_ARCH and display ARCH - ([467395d](https://github.com/pkgforge-dev/appimagetool/commit/467395db4738dc99c455f484a41236a46dc0c87c))
+
+### 🐛 Bug Fixes
+
+- *(uruntime)* Pin default URL to v0.5.7 for reproducible builds - ([91fd541](https://github.com/pkgforge-dev/appimagetool/commit/91fd54158dc41e52c8b4bb2ccb57ac6a430f6fd2))
+
+### 📚 Documentation
+
+- Rewrite README for clarity - ([0897b5f](https://github.com/pkgforge-dev/appimagetool/commit/0897b5fbca6470b38ff83893f546a315187c22bb))
+
 ## [0.1.0] - 2026-05-03
 
 ### ⛰️  Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "appimagetool"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "appimagetool"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 description = "A tool for creating AppImages"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `appimagetool`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `appimagetool` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CliArgs.appimage_arch in /tmp/.tmp00T6Fh/appimagetool/src/config.rs:80
  field CliArgs.keep_mount in /tmp/.tmp00T6Fh/appimagetool/src/config.rs:105
  field CliArgs.devel_release in /tmp/.tmp00T6Fh/appimagetool/src/config.rs:108
  field CliArgs.profile_timeout in /tmp/.tmp00T6Fh/appimagetool/src/config.rs:110
  field Config.appimage_arch in /tmp/.tmp00T6Fh/appimagetool/src/config.rs:30
  field Config.profile_timeout in /tmp/.tmp00T6Fh/appimagetool/src/config.rs:63
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/pkgforge-dev/appimagetool/compare/0.1.0...0.2.0) - 2026-05-04

### ⛰️  Features

- *(config)* Expose keep-mount, devel-release, and profile-timeout - ([b3db290](https://github.com/pkgforge-dev/appimagetool/commit/b3db290c18c43fa38e228b6f49dfd7cfa8ed1bfd))
- *(config)* Split arch into runtime APPIMAGE_ARCH and display ARCH - ([467395d](https://github.com/pkgforge-dev/appimagetool/commit/467395db4738dc99c455f484a41236a46dc0c87c))

### 🐛 Bug Fixes

- *(uruntime)* Pin default URL to v0.5.7 for reproducible builds - ([91fd541](https://github.com/pkgforge-dev/appimagetool/commit/91fd54158dc41e52c8b4bb2ccb57ac6a430f6fd2))

### 📚 Documentation

- Rewrite README for clarity - ([0897b5f](https://github.com/pkgforge-dev/appimagetool/commit/0897b5fbca6470b38ff83893f546a315187c22bb))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).