### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## [0.3.0](https://github.com/pkgforge-dev/appimagetool/compare/0.2.0...0.3.0) - 2026-05-08
+
+### 🐛 Bug Fixes
+
+- *(uruntime)* Scan whole binary for URUNTIME_MOUNT marker - ([395644b](https://github.com/pkgforge-dev/appimagetool/commit/395644b32d1b829f0c33dceb2d48b56bed5c3bac))
+
 ## [0.2.0](https://github.com/pkgforge-dev/appimagetool/compare/0.1.0...0.2.0) - 2026-05-04
 
 ### ⛰️  Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "appimagetool"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "appimagetool"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 description = "A tool for creating AppImages"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `appimagetool`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `appimagetool` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function appimagetool::elf::patch_section_string, previously in file /tmp/.tmpVG7gPu/appimagetool/src/elf.rs:157
  function appimagetool::elf::find_section, previously in file /tmp/.tmpVG7gPu/appimagetool/src/elf.rs:111
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/pkgforge-dev/appimagetool/compare/0.2.0...0.3.0) - 2026-05-08

### 🐛 Bug Fixes

- *(uruntime)* Scan whole binary for URUNTIME_MOUNT marker - ([395644b](https://github.com/pkgforge-dev/appimagetool/commit/395644b32d1b829f0c33dceb2d48b56bed5c3bac))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).