### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 
+## [0.3.1](https://github.com/pkgforge-dev/appimagetool/compare/0.3.0...0.3.1) - 2026-06-07
+
 ## [0.3.0](https://github.com/pkgforge-dev/appimagetool/compare/0.2.0...0.3.0) - 2026-05-08
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "appimagetool"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "appimagetool"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "A tool for creating AppImages"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `appimagetool`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).