### PR TITLE
add support for `riscv64`, `loongarch64`, `powerpc64` and `ppc64le`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,33 @@ jobs:
               RUNNER: ubuntu-24.04-arm,
               TARGET: aarch64-unknown-linux-musl,
             }
+          - {
+              NAME: riscv64-linux,
+              RUNNER: ubuntu-latest,
+              TARGET: riscv64gc-unknown-linux-musl,
+              ZIGTARGET: riscv64-linux-musl,
+            }
+          - {
+              NAME: loongarch64-linux,
+              RUNNER: ubuntu-latest,
+              TARGET: loongarch64-unknown-linux-musl,
+              ZIGTARGET: loongarch64-linux-musl,
+            }
+          - {
+              NAME: ppc64-linux,
+              RUNNER: ubuntu-latest,
+              TARGET: powerpc64-unknown-linux-musl,
+              ZIGTARGET: powerpc64-linux-musl,
+            }
+          - {
+              NAME: ppc64le-linux,
+              RUNNER: ubuntu-latest,
+              TARGET: powerpc64le-unknown-linux-musl,
+              ZIGTARGET: powerpc64le-linux-musl,
+            }
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set the release version
         shell: bash
@@ -47,13 +71,58 @@ jobs:
           sudo apt-get install -y --no-install-recommends musl-tools b3sum
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # nightly
         with:
           targets: ${{ matrix.build.TARGET }}
           components: rust-src
 
+      - name: Install zig
+        if: ${{ matrix.build.ZIGTARGET }}
+        run: |
+          curl -fL --retry 3 -o "$RUNNER_TEMP/zig.tar.xz" \
+            "https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz"
+          echo "70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00  $RUNNER_TEMP/zig.tar.xz" | sha256sum -c -
+          mkdir -p "$RUNNER_TEMP/zig"
+          tar xJf "$RUNNER_TEMP/zig.tar.xz" -C "$RUNNER_TEMP/zig" --strip-components=1
+
+      - name: Create zig-cc linker wrapper
+        if: ${{ matrix.build.ZIGTARGET }}
+        run: |
+          {
+            echo '#!/bin/bash'
+            echo 'args=()'
+            echo 'for a in "$@"; do'
+            echo '  case "$a" in'
+            echo '    *fix-cortex-a53-843419*) continue ;;'
+            echo '    -nostartfiles) continue ;;'
+            echo '    crt1.o|Scrt1.o|rcrt1.o|crti.o|crtn.o) continue ;;'
+            echo '    crtbegin.o|crtend.o|crtbeginS.o|crtendS.o) continue ;;'
+            echo '    -lc) continue ;;'
+            echo '    */self-contained/*.o) continue ;;'
+            echo '    --target=*-unknown-linux-*)'
+            echo '      t="${a#--target=}"'
+            echo '      t="${t/-unknown-linux-/-linux-}"'
+            echo '      args+=("-target" "$t")'
+            echo '      ;;'
+            echo '    *) args+=("$a") ;;'
+            echo '  esac'
+            echo 'done'
+            echo "exec \"$RUNNER_TEMP/zig/zig\" cc -target ${{ matrix.build.ZIGTARGET }} \"\${args[@]}\""
+          } > "$RUNNER_TEMP/zigcc"
+          chmod +x "$RUNNER_TEMP/zigcc"
+
       - name: Build
-        run: cargo build --release --locked --target ${{ matrix.build.TARGET }} -Z build-std=std,panic_abort
+        run: |
+          if [ -n "${{ matrix.build.ZIGTARGET }}" ]; then
+            TENV=$(echo "${{ matrix.build.TARGET }}" | tr 'a-z-' 'A-Z_')
+            export CARGO_TARGET_${TENV}_LINKER="$RUNNER_TEMP/zigcc"
+            # CARGO_TARGET_RUSTFLAGS (not RUSTFLAGS) so the flags do not leak
+            # into build scripts
+            export CARGO_TARGET_RUSTFLAGS="-C target-feature=+crt-static -C link-self-contained=no"
+            export ZIG_GLOBAL_CACHE_DIR="$RUNNER_TEMP/zig-cache"
+            export ZIG_LOCAL_CACHE_DIR="$RUNNER_TEMP/zig-cache"
+          fi
+          cargo build --release --locked --target ${{ matrix.build.TARGET }} -Z build-std=std,panic_abort
 
       - name: Prepare release assets
         shell: bash
@@ -71,7 +140,7 @@ jobs:
           b3sum appimagetool-${{ matrix.build.NAME }}.tar.xz > appimagetool-${{ matrix.build.NAME }}.tar.xz.b3sum
 
       - name: Upload to release
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: appimagetool-${{ matrix.build.NAME }}*
@@ -80,7 +149,7 @@ jobs:
           tag: ${{ github.ref }}
 
       - name: Attest Build Provenance
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
           subject-name: "appimagetool-${{ matrix.build.NAME }}"
           subject-path: appimagetool-${{ matrix.build.NAME }}*

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A Rust implementation of `appimagetool` for the [Anylinux-AppImages](https://github.com/pkgforge-dev/Anylinux-AppImages) project.
 
-It takes a prepared AppDir and produces a finished `.AppImage` using DWARFS compression and the [uruntime](https://github.com/VHSgunzo/uruntime) AppImage runtime. Single binary, no Python, no C++ deps.
+It takes a prepared AppDir and produces a finished `.AppImage` using DWARFS compression and the [uruntime](https://github.com/pkgforge-dev/Anylinux-uruntime) AppImage runtime. Single binary, no Python, no C++ deps.
 
 ## Quick start
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -119,11 +119,14 @@ impl Config {
         let appimage_arch = args
             .appimage_arch
             .or_else(|| env_opt("APPIMAGE_ARCH"))
-            .unwrap_or_else(|| match env::consts::ARCH {
-                "x86_64" => "x86_64".to_string(),
-                "aarch64" => "aarch64".to_string(),
-                other => other.to_string(),
-            });
+            .unwrap_or_else(|| env::consts::ARCH.to_string());
+        // Normalize rust arch spellings to the uname -m equivalent so the
+        // download URLs resolve (e.g. powerpc64le -> ppc64le).
+        let appimage_arch = match appimage_arch.as_str() {
+            "powerpc64" => "ppc64".to_string(),
+            "powerpc64le" => "ppc64le".to_string(),
+            other => other.to_string(),
+        };
         let arch = args.arch.unwrap_or_else(|| appimage_arch.clone());
 
         let appdir = args.appdir.unwrap_or_else(|| PathBuf::from("./AppDir"));

--- a/src/uruntime.rs
+++ b/src/uruntime.rs
@@ -14,7 +14,9 @@ const MOUNT_MARKER: &[u8] = b"URUNTIME_MOUNT=";
 /// Default uruntime download URL pattern. Pinned for reproducible builds;
 /// override with `--runtime-url` / `URUNTIME_LINK` to track a different
 /// release. `{arch}` gets replaced with the target architecture.
-const DEFAULT_URL_TEMPLATE: &str = "https://github.com/VHSgunzo/uruntime/releases/download/v0.5.9/uruntime-appimage-dwarfs-lite-{arch}";
+/// Points at our dwarfs-only uruntime fork, which publishes builds for
+/// every architecture appimagetool supports.
+const DEFAULT_URL_TEMPLATE: &str = "https://github.com/pkgforge-dev/Anylinux-uruntime/releases/download/1.0.0/uruntime-appimage-lite-{arch}";
 
 /// Ensure a runtime binary is available. Returns the path to the runtime.
 ///


### PR DESCRIPTION
## Summary

- **build all six architectures in CI**: `x86_64`, `aarch64`, `riscv64`, `loongarch64`, `powerpc64` and `ppc64le`. the four new ones cross-compile with zig-cc (same setup as Anylinux-sharun and Anylinux-uruntime); artifact names follow `uname -m`
- **default uruntime switched to our fork**: the previous default (VHSgunzo v0.5.9) only ships x86_64 + aarch64 binaries. now defaults to `pkgforge-dev/Anylinux-uruntime` `1.0.0` — our dwarfs-only fork — which publishes `uruntime-appimage-lite-{arch}` for all six arches
- **arch normalization**: rust arch spellings are normalized to `uname -m` equivalents (`powerpc64` -> `ppc64`, `powerpc64le` -> `ppc64le`) so the download urls resolve regardless of who asks
- **github actions pinned to commit shas**

## Requirements

- ⚠ **requires the Anylinux-uruntime `1.0.0` release to be published** (the version bump is already on that repo's main; tagging `1.0.0` triggers its release CI)

## Notes

- verified locally: `cargo test` (68 passed) and a cross-pack run (`--appimage-arch aarch64` from an x86_64 host downloads the aarch64 uruntime + mkdwarfs and produces an aarch64 AppImage)
- note: `ARCH` (display) and `APPIMAGE_ARCH` (runtime/download) are separate by design — `ARCH` is env-overridable so projects can publish under aliases like `amd64`; cross-packing only needs `APPIMAGE_ARCH` or `--appimage-arch` set to the target

