### PR TITLE
chore: release v0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## [0.3.6] - 2026-09-01
+
+### ◀️ Revert
+
+- Revert zstd 19, doesn't really improve compression time and increases appimage size by 7% - ([1bd21ef](https://github.com/pkgforge-dev/appimagetool/commit/1bd21efadbc72ecc5f3d2fbaea9b7a789f824c83))
+
 ## [0.3.5] - 2026-09-01
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "appimagetool"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "clap",
  "libc",


### PR DESCRIPTION



## 🤖 New release

* `appimagetool`: 0.3.5 -> 0.3.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.6] - 2026-09-01

### ◀️ Revert

- Revert zstd 19, doesn't really improve compression time and increases appimage size by 7% - ([1bd21ef](https://github.com/pkgforge-dev/appimagetool/commit/1bd21efadbc72ecc5f3d2fbaea9b7a789f824c83))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).